### PR TITLE
投稿作成機能の実装

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,7 @@ class CoursesController < ApplicationController
       redirect_to courses_path, success: t('defaults.message.created')
     else
       flash.now['danger'] = t('defaults.message.not_created')
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,4 +2,30 @@ class CoursesController < ApplicationController
   def index
     @courses = Course.all.includes(:user).order(created_at: :desc)
   end
+
+
+  def new
+    @course = Course.new
+  end
+
+  def create
+    @course = current_user.courses.build(course_params)
+    if @course.save
+      redirect_to courses_path, success: t('defaults.message.created')
+    else
+      flash.now['danger'] = t('defaults.message.not_created')
+      render :new
+    end
+  end
+
+  def show
+    @course = Course.find(params[:id])
+  end
+
+
+  private
+
+  def course_params
+    params.require(:course).permit(:title, :description)
+  end
 end

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,6 +1,6 @@
 <div class="card w-96 bg-base-100 shadow-xl">
   <figure>
-    <%= image_tag course.image %>
+    <%#= image_tag course.image %>
   </figure>
   <div class="card-body">
     <h2 class="card-title">

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: course, class: "max-w-screen-md grid sm:grid-cols-2 gap-4 mx-auto", local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="sm:col-span-2">
+    <%= f.label :title, class: "inline-block text-sm sm:text-base mb-2" %>
+    <%= f.text_field :title, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2" %>
+  </div>
+  <div class="sm:col-span-2">
+    <%= f.label :description, class: "inline-block text-sm sm:text-base mb-2" %>
+    <%= f.text_area :description, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2" %>
+  </div>
+  <div class="sm:col-span-2 flex justify-between items-center">
+    <%= f.submit t('courses.new.register'), class: "inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3" %>
+  </div>
+<% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div class="mb-10 md:mb-16">
-    <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= (t '.title') %></h2>
+    <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= t('.title') %></h2>
   </div>
   <% if @courses.present? %>
     <div class="card w-96 bg-base-100 shadow-xl">

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -1,0 +1,10 @@
+<div class="py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+    <div class="mb-10 md:mb-16">
+      <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= t('.title') %></h2>
+    </div>
+    <div>
+      <%= render 'form', { course: @course } %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
           <ul tabindex="0" class="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-52 mt-4">
             <li><%= link_to t('defaults.mypage'), "#" %></li>
             <li><%= link_to t('defaults.simulation'), "#" %></li>
-            <li><%= link_to t('defaults.new_post'), "#" %></li>
+            <li><%= link_to t('defaults.new_post'), new_course_path %></li>
             <li><%= link_to t('defaults.post_index'), courses_path %></li>
             <li><%= link_to t('defaults.logout'), logout_path, data: { turbo_method: :delete } %></li>
           </ul>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
-    <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-8"><%= (t '.title') %></h2>
+    <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-8"><%= t('.title') %></h2>
     <%= form_with url: login_path, class: "max-w-lg border rounded-lg mx-auto", local: true do |f| %>
       <div class="flex flex-col gap-4 p-4 md:p-8">
         <div>
@@ -11,7 +11,7 @@
           <%= f.label :password, User.human_attribute_name(:password), class: "inline-block text-sm sm:text-base mb-2" %>
           <%= f.password_field :password, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2" %>
         </div>
-        <button class="block bg-indigo-500 hover:bg-indigo-600 active:bg-gray-600 focus-visible:ring ring-gray-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3"><%= (t '.title') %></button>
+        <button class="block bg-indigo-500 hover:bg-indigo-600 active:bg-gray-600 focus-visible:ring ring-gray-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3"><%= t('.title') %></button>
       </div>
       <div class="flex justify-center items-center bg-gray-100 p-3">
         <p class="text-gray-500 text-sm text-center">新規登録は<%= link_to 'こちら', new_user_path, class: "text-indigo-500 hover:text-indigo-600 active:text-indigo-700 transition duration-100" %></p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <div class="mb-10 md:mb-16">
-      <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= (t '.title') %></h2>
+      <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= t('.title') %></h2>
     </div>
     <%= form_with model: @user, class: "max-w-screen-md grid sm:grid-cols-2 gap-4 mx-auto", local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
@@ -22,7 +22,7 @@
         <%= f.password_field :password_confirmation, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2" %>
       </div>
       <div class="sm:col-span-2 flex justify-between items-center">
-        <%= f.submit '登録', class: "inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3" %>
+        <%= f.submit t('.register'), class: "inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3" %>
       </div>
     <% end %>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,3 +10,6 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード（確認）'
         avatar: 'プロフィール画像'
+      course:
+        title: 'コースタイトル'
+        description: 'コース概要'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,7 +6,7 @@ ja:
     logout: 'ログアウト'
     mypage: 'マイページ'
     simulation: 'シミュレーション'
-    new_post: 'コース登録'
+    new_post: 'コース作成'
     post_index: 'コース一覧'
     terms_of_use: '利用規約'
     privacy_policy: 'プライバシーポリシー'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,3 +36,6 @@ ja:
     index:
       title: 'コース一覧'
       no_result: 'コースがありません'
+    new:
+      title: 'コース作成'
+      register: '作成'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,8 @@ ja:
     contact: 'お問い合わせ'
     message:
       require_login: 'ログインが必要です'
+      created: "コースを作成しました"
+      not_created: "コースを作成できませんでした"
   users:
     new:
       title: 'ユーザー登録'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :courses, only: %i[index]
+  resources :courses, only: %i[new index create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :courses, only: %i[new index create]
+  resources :courses, only: %i[index new create]
 end


### PR DESCRIPTION
## 概要(issue番号)
コース投稿フォームからコースが作成できるようにする。（#44）

## 確認方法
- [x] コースが作成できること
- [x] コース作成後に「コースを作成しました」というフラッシュメッセージが表示されること
- [x] コース作成後にコース一覧画面に遷移すること
- [x] コース作成に失敗した場合に「コースを作成できませんでした」というエラーメッセージが表示されること
- [x] コース作成に失敗した場合に、入力したデータが残った状態で投稿フォームへと戻ること

## コメント
画像アップロード機能は現段階で未実装のため、一時的に画面上で非表示となるようにしている。