### PR TITLE
投稿詳細画面の作成

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,10 +1,10 @@
 <div class="card w-96 bg-base-100 shadow-xl">
   <figure>
-    <%= image_tag course.image_url, class: 'card-img-top', size: '300x200' %>
+    <%= link_to image_tag(course.image_url), course_path(course), class: 'card-img-top', size: '300x200' %>
   </figure>
   <div class="card-body">
     <h2 class="card-title">
-      <%= course.title %>
+      <%= link_to course.title, course_path(course) %>
     </h2>
     <%= course.user.name %>
   </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,0 +1,21 @@
+<div class="py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+    <div class="mb-10 md:mb-16">
+      <h2 class="lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= t('.title') %></h2>
+    </div>
+    <div class="mb-10 md:mb-16">
+      <h2 class="lg:text-3xl font-bold mb-4 md:mb-6"><%= @course.title %></h2>
+    </div>
+    <div class="mb-10 md:mb-16">
+      <%= image_tag @course.image_url %>
+    </div>
+    <div class="mb-10 md:mb-16">
+      <h2 class="lg:text-3xl font-bold mb-4 md:mb-6">作成者</h2>
+      <%= @course.user.name %>
+    </div>
+    <div class="mb-10 md:mb-16">
+      <h2 class="lg:text-3xl font-bold mb-4 md:mb-6">コース説明</h2>
+      <%= @course.description %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,3 +39,5 @@ ja:
     new:
       title: 'コース作成'
       register: '作成'
+    show:
+      title: 'コース詳細'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :courses, only: %i[index new create]
+  resources :courses, only: %i[index new create show]
 end


### PR DESCRIPTION
## 概要(issue番号)
コース一覧画面から該当コースの画像またはタイトルをクリックすると、コース詳細画面に遷移するようにする。（#48）

## 確認方法
- [x] コース一覧の各コース画像およびタイトルからコース詳細画面を表示する。

## コメント
詳細画面に表示される画像のサイズが現状小さいため、これを大きくしたい。後日修正する。